### PR TITLE
Fix image extraction directory

### DIFF
--- a/build_vector_db.py
+++ b/build_vector_db.py
@@ -4,9 +4,9 @@ from dotenv import load_dotenv
 load_dotenv()
 api_key = os.getenv("OPENAI_API_KEY")
 
-from utils.extract_file_utils import extract_pdf_elements, categorize_elements # Updated import
-from utils.summarize import generate_img_summaries, generate_text_summaries # Updated import
-from utils.vector_store import create_multi_vector_retriever # Updated import
+from utils.extract_file_utils import extract_pdf_elements, categorize_elements
+from utils.summarize import generate_img_summaries, generate_text_summaries
+from utils.vector_store import create_multi_vector_retriever
 from langchain_text_splitters import CharacterTextSplitter
 from langchain_openai import OpenAIEmbeddings
 from langchain_chroma import Chroma
@@ -18,7 +18,7 @@ all_texts = []
 all_tables = []
 for fname in os.listdir(fpath):
     if fname != ".gitkeep" and fname.lower().endswith(".pdf"):
-        raw_pdf_elements = extract_pdf_elements(fpath, fname)
+        raw_pdf_elements = extract_pdf_elements(fpath, fname, img_output_dir="figures/")
         texts, tables = categorize_elements(raw_pdf_elements)
         all_texts.extend(texts)
         all_tables.extend(tables)

--- a/utils/extract_file_utils.py
+++ b/utils/extract_file_utils.py
@@ -1,16 +1,31 @@
 from langchain_text_splitters import CharacterTextSplitter
 from unstructured.partition.pdf import partition_pdf
+import os
 
 
-def extract_pdf_elements(path, fname):
+def extract_pdf_elements(pdf_dir, fname, img_output_dir=None):
+    """從 PDF 檔案中提取圖片、表格與分段文字。
+
+    Parameters
+    ----------
+    pdf_dir : str
+        PDF 檔案所在資料夾路徑。
+    fname : str
+        PDF 檔名。
+    img_output_dir : str, optional
+        圖片輸出資料夾路徑，預設與 ``pdf_dir`` 相同。
+
+    Returns
+    -------
+    list
+        unstructured 解析後的元素列表（圖片、表格、文字等）。
     """
-    從 PDF 檔案中提取圖片、表格與分段文字。
-    path: 檔案路徑，會用來存放圖片（.jpg）
-    fname: 檔案名稱
-    回傳：PDF 元素（圖片、表格、文字等）
-    """
+
+    if img_output_dir is None:
+        img_output_dir = pdf_dir
+
     return partition_pdf(
-        filename=path + fname,
+        filename=os.path.join(pdf_dir, fname),
         extract_images_in_pdf=True,
         extract_tables=True,
         infer_table_structure=True,
@@ -18,7 +33,7 @@ def extract_pdf_elements(path, fname):
         max_characters=4000,
         new_after_n_chars=3800,
         combine_text_under_n_chars=2000,
-        image_output_dir_path=path,
+        image_output_dir_path=img_output_dir,
     )
 
 # 目的：方便後續針對不同型態資料進行摘要與檢索。


### PR DESCRIPTION
## Summary
- adjust extraction function to accept separate image output directory
- store PDF images in the dedicated `figures/` folder when building the vector DB

## Testing
- `python -m py_compile main.py utils/*.py build_vector_db.py`

------
https://chatgpt.com/codex/tasks/task_e_6840ea170c9083229a398c7ddb96e68e