### PR TITLE
Refactor file processing utils

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,15 +15,7 @@ from concurrent.futures import ProcessPoolExecutor
 from typing import Optional
 
 import uvicorn
-from fastapi import (
-    Cookie,
-    FastAPI,
-    File,
-    Form,
-    Header,
-    HTTPException,
-    UploadFile,
-)
+from fastapi import Cookie, FastAPI, File, Form, Header, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -250,11 +242,11 @@ async def login(credentials: LoginRequest, response: Response):
 
 # Modified for FAISS
 def add_file_to_vector_db(file_path: str, username: str) -> bool:
-    from utils.extract_file_utils import process_single_file
+    from utils.processing import process_single_file
     from utils.summarize import generate_img_summaries, generate_text_summaries
-    from utils.vector_store import (  # This util needs to be FAISS-aware
+    from utils.vector_store import (
         create_multi_vector_retriever,
-    )
+    )  # This util needs to be FAISS-aware
 
     print(f"\n🔄 處理上傳檔案 (FAISS): {file_path}")
 

--- a/utils/processing/__init__.py
+++ b/utils/processing/__init__.py
@@ -1,13 +1,11 @@
-"""Backward compatibility wrapper for processing utilities."""
+"""Processing utilities for different file types."""
 
-from .processing import (
-    categorize_elements,
-    convert_pdf_to_page_images,
+from .common import categorize_elements, process_single_file
+from .pdf_processing import convert_pdf_to_page_images, extract_pdf_elements
+from .pptx_processing import (
     convert_pptx_to_pdf,
     convert_pptx_to_slide_images,
-    extract_pdf_elements,
     extract_pptx_elements,
-    process_single_file,
 )
 
 __all__ = [

--- a/utils/processing/common.py
+++ b/utils/processing/common.py
@@ -1,0 +1,139 @@
+"""Shared processing helpers."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import List, Tuple
+
+from unstructured.partition.docx import partition_docx
+
+from .pdf_processing import convert_pdf_to_page_images, extract_pdf_elements
+from .pptx_processing import (
+    convert_pptx_to_pdf,
+    convert_pptx_to_slide_images,
+    extract_pptx_elements,
+)
+
+__all__ = ["categorize_elements", "process_single_file"]
+
+
+def categorize_elements(raw_elements: List) -> Tuple[List[str], List[str]]:
+    """Categorize unstructured elements into texts and tables."""
+    tables: List[str] = []
+    texts: List[str] = []
+    for element in raw_elements:
+        element_type = str(type(element))
+        if "unstructured.documents.elements.Table" in element_type:
+            tables.append(str(element))
+        elif "unstructured.documents.elements.CompositeElement" in element_type:
+            texts.append(str(element))
+        elif "unstructured.documents.elements.Title" in element_type:
+            texts.append(str(element))
+        elif "unstructured.documents.elements.NarrativeText" in element_type:
+            texts.append(str(element))
+    return texts, tables
+
+
+def process_single_file(
+    fname: str, fpath: str, database_dir: str = "./database"
+) -> dict:
+    """Process a single file and return extracted information."""
+    file_start_time = time.time()
+    print(f"\n📄 處理文件: {fname}")
+    result = {
+        "texts": [],
+        "tables": [],
+        "page_summaries": [],
+        "page_identifiers": [],
+        "temp_files": [],
+        "file_type": None,
+        "processing_time": 0,
+    }
+    try:
+        if fname.lower().endswith(".pdf"):
+            result["file_type"] = "pdf"
+            extract_start = time.time()
+            print(f"  🔄 開始提取 PDF 元素: {fname}")
+            raw_elements = extract_pdf_elements(fpath, fname, database_dir=database_dir)
+            texts, tables = categorize_elements(raw_elements)
+            result["texts"] = texts
+            result["tables"] = tables
+            print(f"  ✓ 提取元素: {time.time() - extract_start:.2f} 秒")
+            page_conversion_start = time.time()
+            page_image_paths = convert_pdf_to_page_images(
+                fpath, fname, database_dir=database_dir
+            )
+            print(f"  ✓ 頁面轉換: {time.time() - page_conversion_start:.2f} 秒")
+            if page_image_paths:
+                from utils.summarize import generate_pdf_page_summaries
+
+                summary_start = time.time()
+                page_summaries, page_identifiers = generate_pdf_page_summaries(
+                    fpath, fname, page_image_paths
+                )
+                result["page_summaries"] = page_summaries
+                result["page_identifiers"] = page_identifiers
+                print(f"  ✓ 頁面摘要生成: {time.time() - summary_start:.2f} 秒")
+        elif fname.lower().endswith(".pptx") or fname.lower().endswith(".ppt"):
+            result["file_type"] = "pptx"
+            pptx_start = time.time()
+            raw_elements = extract_pptx_elements(
+                fpath, fname, database_dir=database_dir
+            )
+            texts, tables = categorize_elements(raw_elements)
+            result["texts"] = texts
+            result["tables"] = tables
+            print(f"  ✓ PPTX 元素提取: {time.time() - pptx_start:.2f} 秒")
+            conversion_start = time.time()
+            pdf_path = convert_pptx_to_pdf(fpath, fname)
+            if pdf_path:
+                result["temp_files"].append(pdf_path)
+                pdf_filename = os.path.basename(pdf_path)
+                pdf_dir = os.path.dirname(pdf_path)
+                print(f"  ✓ PPTX 轉 PDF: {time.time() - conversion_start:.2f} 秒")
+                page_conversion_start = time.time()
+                page_image_paths = convert_pdf_to_page_images(
+                    pdf_dir, pdf_filename, database_dir=database_dir
+                )
+                print(f"  ✓ PDF 頁面轉換: {time.time() - page_conversion_start:.2f} 秒")
+                if page_image_paths:
+                    from utils.summarize import generate_pdf_page_summaries
+
+                    summary_start = time.time()
+                    page_summaries, page_identifiers = generate_pdf_page_summaries(
+                        pdf_dir, fname, page_image_paths
+                    )
+                    slide_identifiers = [
+                        pid.replace("_page_", "_slide_") for pid in page_identifiers
+                    ]
+                    result["page_summaries"] = page_summaries
+                    result["page_identifiers"] = slide_identifiers
+                    print(f"  ✓ 幻燈片摘要生成: {time.time() - summary_start:.2f} 秒")
+            else:
+                print("  ❌ PPTX 轉 PDF 失敗，無法處理幻燈片")
+        elif fname.lower().endswith(".docx"):
+            result["file_type"] = "docx"
+            print("  ⚠️ DOCX 處理功能尚未完全實現，僅提取文本")
+            try:
+                full_path = os.path.join(fpath, fname)
+                elements = partition_docx(
+                    filename=full_path, extract_images_in_tables=True
+                )
+                texts, tables = categorize_elements(elements)
+                result["texts"] = texts
+                result["tables"] = tables
+                print(
+                    f"  ✓ DOCX 元素提取完成，獲取了 {len(texts)} 個文本段落和 {len(tables)} 個表格"
+                )
+            except Exception as docx_err:
+                print(f"  ❌ DOCX 處理出錯: {docx_err}")
+    except Exception as e:
+        print(f"  ❌ 處理文件 {fname} 時出錯: {str(e)}")
+        import traceback
+
+        traceback.print_exc()
+    processing_time = time.time() - file_start_time
+    result["processing_time"] = processing_time
+    print(f"  ✓ 文件 {fname} 處理完成: {processing_time:.2f} 秒")
+    return result

--- a/utils/processing/pdf_processing.py
+++ b/utils/processing/pdf_processing.py
@@ -1,0 +1,75 @@
+"""PDF related processing utilities."""
+
+import os
+
+from pdf2image import convert_from_path
+from unstructured.partition.pdf import partition_pdf
+
+__all__ = ["convert_pdf_to_page_images", "extract_pdf_elements"]
+
+
+def convert_pdf_to_page_images(
+    file_path: str, file_name: str, database_dir: str = "./database"
+):
+    """Convert each page of a PDF to an image and return the paths."""
+    try:
+        output_dir = f"{database_dir}/figures/{os.path.splitext(file_name)[0]}/pages"
+        os.makedirs(output_dir, exist_ok=True)
+        full_path = os.path.join(file_path, file_name)
+        print(f"🔄 開始處理 PDF: {full_path}")
+        if not os.path.exists(full_path):
+            print(f"❌ 錯誤: PDF 文件不存在: {full_path}")
+            return []
+        file_size = os.path.getsize(full_path) / (1024 * 1024)
+        print(f"📄 PDF 文件大小: {file_size:.2f} MB")
+        try:
+            print(f"🔄 正在將 {file_name} 轉換為頁面圖片...")
+            images = convert_from_path(full_path, dpi=200, thread_count=20)
+            print(f"✅ 成功讀取 {len(images)} 頁")
+        except Exception as e:  # pragma: no cover - conversion can fail in CI
+            print(f"❌ 轉換 PDF 頁面時出錯: {str(e)}")
+            import traceback
+
+            traceback.print_exc()
+            return []
+        page_image_paths = []
+        for i, image in enumerate(images):
+            try:
+                page_num = i + 1
+                image_path = os.path.join(output_dir, f"page_{page_num}.jpg")
+                image.save(image_path, "JPEG")
+                page_image_paths.append((page_num, image_path))
+            except Exception as e:  # pragma: no cover - file system issues
+                print(f"❌ 儲存頁面 {i+1} 時出錯: {str(e)}")
+        print(f"✅ 已將 {file_name} 的 {len(images)} 頁轉換為圖片")
+        return page_image_paths
+    except Exception as e:  # pragma: no cover - unexpected errors
+        print(f"❌ 處理 PDF 文件 {file_name} 時發生未預期的錯誤: {str(e)}")
+        import traceback
+
+        traceback.print_exc()
+        return []
+
+
+def extract_pdf_elements(
+    file_path: str, file_name: str, database_dir: str = "./database"
+):
+    """Extract text, tables and images from a PDF."""
+    output_dir = f"{database_dir}/figures/{os.path.splitext(file_name)[0]}"
+    os.makedirs(output_dir, exist_ok=True)
+    full_path = os.path.join(file_path, file_name)
+    elements = partition_pdf(
+        filename=full_path,
+        extract_images_in_pdf=False,
+        infer_table_structure=True,
+        chunking_strategy="by_title",
+        max_characters=8192,
+        new_after_n_chars=3800,
+        combine_text_under_n_chars=2000,
+        image_output_dir_path=output_dir,
+        extract_image_block_output_dir=output_dir,
+        strategy="hi_res",
+        hi_res_model_name="yolox",
+        languages=["eng", "chi_tra", "chi_tra_vert"],
+    )
+    return elements

--- a/utils/processing/pptx_processing.py
+++ b/utils/processing/pptx_processing.py
@@ -1,0 +1,265 @@
+"""PPTX related processing utilities."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import uuid
+from typing import List, Tuple
+
+from PIL import Image
+from pptx import Presentation
+from unstructured.cleaners.core import clean_extra_whitespace
+from unstructured.partition.pptx import partition_pptx
+
+__all__ = [
+    "convert_pptx_to_slide_images",
+    "convert_pptx_to_pdf",
+    "extract_pptx_elements",
+]
+
+
+def convert_pptx_to_slide_images(
+    file_path: str, file_name: str, database_dir: str = "./database"
+) -> List[Tuple[int, str]]:
+    """Convert each PPTX slide to an image and return the paths."""
+    try:
+        output_dir = f"{database_dir}/figures/{os.path.splitext(file_name)[0]}/slides"
+        os.makedirs(output_dir, exist_ok=True)
+        full_path = os.path.join(file_path, file_name)
+        print(f"🔄 開始處理 PPTX: {full_path}")
+        if not os.path.exists(full_path):
+            print(f"❌ 錯誤: PPTX 文件不存在: {full_path}")
+            return []
+        file_size = os.path.getsize(full_path) / (1024 * 1024)
+        print(f"📄 PPTX 文件大小: {file_size:.2f} MB")
+        try:
+            print(f"🔄 正在載入 {file_name}...")
+            presentation = Presentation(full_path)
+            print(f"✅ 成功載入 {len(presentation.slides)} 張幻燈片")
+        except Exception as e:
+            print(f"❌ 載入 PPTX 文件時出錯: {str(e)}")
+            import traceback
+
+            traceback.print_exc()
+            return []
+        slide_image_paths: List[Tuple[int, str]] = []
+        for i, slide in enumerate(presentation.slides):
+            try:
+                slide_num = i + 1
+                slide_path = os.path.join(output_dir, f"slide_{slide_num}.jpg")
+                slide_width, slide_height = 1920, 1080
+                slide_image = Image.new(
+                    "RGB", (slide_width, slide_height), color="white"
+                )
+                from PIL import ImageDraw, ImageFont
+
+                draw = ImageDraw.Draw(slide_image)
+                try:
+                    font = ImageFont.truetype("Arial", 20)
+                except IOError:
+                    font = ImageFont.load_default()
+                y_position = 50
+                if slide.shapes.title:
+                    title_text = slide.shapes.title.text
+                    draw.text(
+                        (50, y_position),
+                        f"Title: {title_text}",
+                        fill="black",
+                        font=font,
+                    )
+                    y_position += 40
+                for shape in slide.shapes:
+                    if hasattr(shape, "text") and shape.text:
+                        lines = shape.text.split("\n")
+                        for line in lines:
+                            if line.strip():
+                                draw.text(
+                                    (50, y_position), line, fill="black", font=font
+                                )
+                                y_position += 30
+                slide_image.save(slide_path, "JPEG")
+                slide_image_paths.append((slide_num, slide_path))
+                print(f"  ✓ 已儲存幻燈片 {slide_num} 圖像")
+            except Exception as e:
+                print(f"❌ 處理幻燈片 {i+1} 時出錯: {str(e)}")
+        print(
+            f"✅ 已將 {file_name} 的 {len(slide_image_paths)}/{len(presentation.slides)} 張幻燈片轉換為圖片"
+        )
+        return slide_image_paths
+    except Exception as e:
+        print(f"❌ 處理 PPTX 文件 {file_name} 時發生未預期的錯誤: {str(e)}")
+        import traceback
+
+        traceback.print_exc()
+        return []
+
+
+def convert_pptx_to_pdf(file_path: str, file_name: str) -> str | None:
+    """Convert a PPTX file to a temporary PDF and return its path."""
+    try:
+        full_path = os.path.join(file_path, file_name)
+        if not os.path.exists(full_path):
+            print(f"❌ 錯誤: PPTX 文件不存在: {full_path}")
+            return None
+        if not os.access(full_path, os.R_OK):
+            print(f"❌ 錯誤: 沒有讀取 PPTX 文件的權限: {full_path}")
+            try:
+                os.chmod(full_path, 0o644)
+                print("  ✓ 已嘗試修改檔案權限")
+            except Exception as e:
+                print(f"  ⚠️ 無法修改檔案權限: {e}")
+                return None
+        temp_dir = tempfile.mkdtemp()
+        ascii_temp_dir = tempfile.mkdtemp()
+        ascii_file_name = f"pptx_{uuid.uuid4().hex}.pptx"
+        ascii_file_path = os.path.join(ascii_temp_dir, ascii_file_name)
+        try:
+            shutil.copy2(full_path, ascii_file_path)
+            print(f"  ✓ 已創建臨時檔案副本: {ascii_file_path}")
+        except Exception as e:
+            print(f"  ❌ 無法創建檔案副本: {e}")
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            shutil.rmtree(ascii_temp_dir, ignore_errors=True)
+            return None
+        pdf_name = f"{os.path.splitext(file_name)[0]}.pdf"
+        output_pdf = os.path.join(temp_dir, pdf_name)
+        ascii_output_pdf = os.path.join(
+            temp_dir, f"{os.path.splitext(ascii_file_name)[0]}.pdf"
+        )
+        print(f"🔄 開始將 PPTX 轉換為 PDF: {ascii_file_path}")
+        try:
+            env = os.environ.copy()
+            env["LC_ALL"] = "C"
+            env["LANG"] = "C"
+            conversion_methods = [
+                {
+                    "cmd": [
+                        "libreoffice",
+                        "--headless",
+                        "--convert-to",
+                        "pdf",
+                        "--outdir",
+                        temp_dir,
+                        ascii_file_path,
+                    ],
+                    "env": env,
+                    "name": "標準方法",
+                },
+                {
+                    "cmd": [
+                        "libreoffice",
+                        "--headless",
+                        "--convert-to",
+                        "pdf:writer_pdf_Export",
+                        "--outdir",
+                        temp_dir,
+                        ascii_file_path,
+                    ],
+                    "env": env,
+                    "name": "PDF導出過濾器方法",
+                },
+                {
+                    "cmd": [
+                        "libreoffice",
+                        "--headless",
+                        "--infilter=impress_MS_PowerPoint_2007_XML",
+                        "--convert-to",
+                        "pdf",
+                        "--outdir",
+                        temp_dir,
+                        ascii_file_path,
+                    ],
+                    "env": env,
+                    "name": "PowerPoint過濾器方法",
+                },
+            ]
+            success = False
+            for method in conversion_methods:
+                if success:
+                    break
+                try:
+                    print(
+                        f"  🔄 嘗試使用{method['name']}轉換: {' '.join(method['cmd'])}"
+                    )
+                    result = subprocess.run(
+                        method["cmd"],
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                        env=method["env"],
+                        timeout=120,
+                    )
+                    if os.path.exists(ascii_output_pdf):
+                        try:
+                            shutil.move(ascii_output_pdf, output_pdf)
+                            print(
+                                f"  ✓ {method['name']}成功: 已將 {ascii_output_pdf} 重命名為 {output_pdf}"
+                            )
+                            success = True
+                            break
+                        except Exception as e:
+                            print(f"  ⚠️ 重命名PDF文件時出錯: {e}")
+                    elif os.path.exists(output_pdf):
+                        print(f"  ✓ {method['name']}成功: 生成了 {output_pdf}")
+                        success = True
+                        break
+                    else:
+                        print(f"  ❌ {method['name']}失敗: 沒有生成PDF文件")
+                        if result.returncode != 0:
+                            print(f"  命令返回碼: {result.returncode}")
+                        if result.stdout:
+                            print(f"  命令輸出: {result.stdout}")
+                        if result.stderr:
+                            print(f"  命令錯誤: {result.stderr}")
+                except subprocess.TimeoutExpired:
+                    print(f"  ⚠️ {method['name']}轉換超時")
+                except Exception as e:
+                    print(f"  ❌ 執行{method['name']}時出錯: {e}")
+            if success and os.path.exists(output_pdf):
+                pdf_size = os.path.getsize(output_pdf) / 1024
+                if pdf_size < 5:
+                    print(
+                        f"  ⚠️ 警告：生成的 PDF 文件非常小 ({pdf_size:.2f} KB)，可能轉換不完整"
+                    )
+                try:
+                    shutil.rmtree(ascii_temp_dir, ignore_errors=True)
+                except Exception:
+                    pass
+                return output_pdf
+            print("  ❌ 所有轉換方法都失敗了")
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            shutil.rmtree(ascii_temp_dir, ignore_errors=True)
+            return None
+        except Exception as e:
+            print(f"  ❌ 轉換過程中出錯: {str(e)}")
+            import traceback
+
+            traceback.print_exc()
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            shutil.rmtree(ascii_temp_dir, ignore_errors=True)
+            return None
+    except Exception as e:
+        print(f"❌ 處理 PPTX 文件 {file_name} 時發生未預期的錯誤: {str(e)}")
+        import traceback
+
+        traceback.print_exc()
+        return None
+
+
+def extract_pptx_elements(path: str, fname: str, database_dir: str = "./database"):
+    """Extract elements from a PPTX file."""
+    output_dir = f"{database_dir}/figures/{os.path.splitext(fname)[0]}"
+    os.makedirs(output_dir, exist_ok=True)
+    full_path = os.path.join(path, fname)
+    elements = partition_pptx(
+        filename=full_path,
+        extract_images_in_tables=True,
+        image_output_dir_path=output_dir,
+    )
+    cleaned_elements = []
+    for element in elements:
+        if hasattr(element, "text"):
+            element.text = clean_extra_whitespace(element.text)
+        cleaned_elements.append(element)
+    return cleaned_elements


### PR DESCRIPTION
## Summary
- break up `extract_file_utils.py` into dedicated modules under `utils/processing`
- adjust imports to use new package
- keep `extract_file_utils.py` as a thin wrapper for backward compatibility

## Testing
- `isort utils/processing/pdf_processing.py utils/processing/pptx_processing.py utils/processing/common.py utils/processing/__init__.py utils/extract_file_utils.py app.py`
- `black utils/processing/pdf_processing.py utils/processing/pptx_processing.py utils/processing/common.py utils/processing/__init__.py utils/extract_file_utils.py app.py`
- `pytest -q`
- `python -m py_compile app.py utils/processing/*.py utils/extract_file_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684b75ca09c883229cae2ba83bedb67b