### PR TITLE
Pass figure_dir to RAG chain

### DIFF
--- a/app.py
+++ b/app.py
@@ -178,7 +178,7 @@ def refresh_retriever(username: str):
                 id_key="doc_id",
             )
 
-            chain = multi_modal_rag_chain(retriever)
+            chain = multi_modal_rag_chain(retriever, user_paths["figure_path"])
 
             user_retrievers[username] = {
                 "retriever": retriever,


### PR DESCRIPTION
## Summary
- make `split_image_text_types` accept `figure_dir`
- pass user `figure_dir` when building the RAG chain
- add regression test for loading images with different figure directories
- stub heavy dependencies in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7dd412108322993d633f776786d4