### PR TITLE
Fix docling image summary

### DIFF
--- a/tests/test_docling_markdown.py
+++ b/tests/test_docling_markdown.py
@@ -1,0 +1,46 @@
+import importlib
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Stub external dependencies before importing the module under test
+stub_converter_module = types.ModuleType("docling.document_converter")
+stub_converter_module.DocumentConverter = lambda: None
+sys.modules["docling.document_converter"] = stub_converter_module
+
+stub_base_module = types.ModuleType("docling_core.types.doc.base")
+stub_base_module.ImageRefMode = object
+sys.modules["docling_core.types.doc.base"] = stub_base_module
+
+import utils.docling_markdown as dm
+
+
+class DummyDoc:
+    def export_to_markdown(self, image_placeholder="<!-- image -->"):
+        return f"Intro {image_placeholder} Outro {image_placeholder}"
+
+    def _list_images_on_disk(self):
+        return [Path("img1.png"), Path("img2.png")]
+
+
+class DummyConverter:
+    def convert(self, path):
+        return types.SimpleNamespace(document=DummyDoc())
+
+
+def test_convert_file_to_markdown_replaces_placeholders(monkeypatch):
+    monkeypatch.setattr(dm, "DocumentConverter", lambda: DummyConverter())
+    summaries = ["summary1", "summary2"]
+
+    def fake_summarize_image(image_path):
+        return summaries.pop(0)
+
+    monkeypatch.setattr(dm, "_summarize_image", fake_summarize_image)
+    markdown = dm.convert_file_to_markdown("dummy.pdf")
+    assert markdown == "Intro summary1 Outro summary2"

--- a/utils/docling_markdown.py
+++ b/utils/docling_markdown.py
@@ -9,7 +9,10 @@ from typing import List
 from docling.document_converter import DocumentConverter
 from docling_core.types.doc.base import ImageRefMode
 
+from utils.logging_config import get_logger
 from utils.summarize import encode_image
+
+logger = get_logger(__name__)
 
 
 def _summarize_image(image_path: str) -> str:
@@ -30,8 +33,11 @@ def _summarize_image(image_path: str) -> str:
             ],
         }
     ]
-    # return llm.invoke(messages).content.strip()
-    return "這是一張圖片的摘要。"  # Placeholder for actual LLM response
+    try:
+        return llm.invoke(messages).content.strip()
+    except Exception as e:
+        logger.error(f"[docling_markdown] Error summarizing image {image_path}: {e}")
+        return "無法生成圖片摘要"
 
 
 def convert_file_to_markdown(path: str) -> str:


### PR DESCRIPTION
## Summary
- use live GPT-4o summary in docling utilities
- handle API failures when summarizing images
- add test verifying image summaries insert into Markdown

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684b7e15a3bc8322801551b15b1b34cc