### PR TITLE
Add file listing API and frontend deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,15 @@ uvicorn app:app --host 0.0.0.0 --port 1230 --reload
 
 - `/mm_rag/reset` API 可一鍵清空所有上傳文件、FAISS 向量庫、docstore 映射。
 
-### 6️⃣ 使用網頁介面
+### 6️⃣ 刪除單一文件
+
+- `/mm_rag/delete` API 可移除指定檔名相關的向量與圖片資料。
+
+### 7️⃣ 查看已上傳檔案
+
+- `/mm_rag/files` 會列出目前使用者上傳的所有檔名。
+
+### 8️⃣ 使用網頁介面
 
 1. 啟動 API 後，前往 `http://localhost:1230/mm_rag/web/` 會看到以 `react-login-page` 風格打造的登入畫面。
 2. 依照 `database/users.json` 中的帳號密碼登入。
@@ -121,6 +129,15 @@ uvicorn app:app --host 0.0.0.0 --port 1230 --reload
 ### 4. 重置系統
 - `POST /mm_rag/reset`
 - 回傳：重置狀態、訊息、時間戳
+
+### 5. 刪除單一文件
+- `POST /mm_rag/delete`
+- 參數：`file_name` (str)
+- 回傳：刪除結果
+
+### 6. 查看已上傳檔案
+- `GET /mm_rag/files`
+- 回傳：檔名列表
 
 ---
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -53,7 +53,7 @@
         <div id="files-area" class="box">
             <h2 class="subtitle">已上傳檔案</h2>
             <table class="table is-fullwidth" id="files-table">
-                <thead><tr><th>檔名</th><th>狀態</th><th>訊息</th></tr></thead>
+                <thead><tr><th>檔名</th><th>狀態</th><th>訊息</th><th>操作</th></tr></thead>
                 <tbody></tbody>
             </table>
         </div>

--- a/tests/test_docling_markdown.py
+++ b/tests/test_docling_markdown.py
@@ -18,6 +18,68 @@ stub_base_module = types.ModuleType("docling_core.types.doc.base")
 stub_base_module.ImageRefMode = object
 sys.modules["docling_core.types.doc.base"] = stub_base_module
 
+# Additional stubs for langchain to avoid heavy deps
+dummy_core = types.ModuleType("langchain_core")
+dummy_core.messages = types.ModuleType("langchain_core.messages")
+dummy_core.messages.HumanMessage = object
+dummy_core.output_parsers = types.ModuleType("langchain_core.output_parsers")
+dummy_core.output_parsers.StrOutputParser = object
+dummy_core.prompts = types.ModuleType("langchain_core.prompts")
+dummy_core.prompts.ChatPromptTemplate = object
+sys.modules.setdefault("langchain_core", dummy_core)
+sys.modules.setdefault("langchain_core.messages", dummy_core.messages)
+sys.modules.setdefault("langchain_core.output_parsers", dummy_core.output_parsers)
+sys.modules.setdefault("langchain_core.prompts", dummy_core.prompts)
+
+dummy_openai = types.ModuleType("langchain_openai")
+dummy_openai.chat_models = types.ModuleType("langchain_openai.chat_models")
+
+
+class _Dummy:
+    def __init__(self, *a, **k):
+        pass
+
+
+dummy_openai.chat_models.ChatOpenAI = _Dummy
+dummy_openai.OpenAIEmbeddings = _Dummy
+dummy_openai.ChatOpenAI = _Dummy
+dummy_openai.OpenAIEmbeddings = _Dummy
+sys.modules.setdefault("langchain_openai", dummy_openai)
+sys.modules.setdefault("langchain_openai.chat_models", dummy_openai.chat_models)
+
+dummy_callbacks = types.ModuleType("langchain.callbacks.streaming_stdout")
+dummy_callbacks.StreamingStdOutCallbackHandler = object
+sys.modules.setdefault("langchain.callbacks", types.ModuleType("langchain.callbacks"))
+sys.modules.setdefault("langchain.callbacks.streaming_stdout", dummy_callbacks)
+
+sys.modules.setdefault(
+    "langchain.retrievers.multi_vector",
+    types.ModuleType("langchain.retrievers.multi_vector"),
+)
+sys.modules["langchain.retrievers.multi_vector"].MultiVectorRetriever = object
+sys.modules.setdefault("langchain.storage", types.ModuleType("langchain.storage"))
+sys.modules["langchain.storage"].InMemoryStore = object
+sys.modules.setdefault(
+    "langchain_community.vectorstores",
+    types.ModuleType("langchain_community.vectorstores"),
+)
+sys.modules["langchain_community.vectorstores"].FAISS = object
+sys.modules.setdefault(
+    "langchain_core.documents", types.ModuleType("langchain_core.documents")
+)
+sys.modules["langchain_core.documents"].Document = object
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+dummy_ipython = types.ModuleType("IPython")
+dummy_ipython.display = types.ModuleType("IPython.display")
+dummy_ipython.display.HTML = lambda *a, **k: None
+dummy_ipython.display.display = lambda *a, **k: None
+sys.modules.setdefault("IPython", dummy_ipython)
+sys.modules.setdefault("IPython.display", dummy_ipython.display)
+
+dummy_dotenv = types.ModuleType("dotenv")
+dummy_dotenv.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault("dotenv", dummy_dotenv)
+
 import utils.docling_markdown as dm
 
 

--- a/tests/test_file_management.py
+++ b/tests/test_file_management.py
@@ -1,0 +1,78 @@
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Stub heavy dependencies before importing app
+for name in [
+    "langchain_core",
+    "langchain_core.messages",
+    "langchain_core.output_parsers",
+    "langchain_core.prompts",
+    "langchain_openai",
+    "langchain_openai.chat_models",
+    "langchain.callbacks",
+    "langchain.callbacks.streaming_stdout",
+    "langchain.retrievers.multi_vector",
+    "langchain.storage",
+    "langchain_community.vectorstores",
+    "langchain_core.documents",
+    "langchain_text_splitters",
+    "numpy",
+    "IPython",
+    "IPython.display",
+    "dotenv",
+    "main",
+    "utils.LLM_Tool",
+]:
+    if name not in sys.modules:
+        sys.modules[name] = ModuleType(name)
+
+sys.modules["langchain_core"].messages = ModuleType("langchain_core.messages")
+sys.modules["langchain_core"].output_parsers = ModuleType(
+    "langchain_core.output_parsers"
+)
+sys.modules["langchain_core"].prompts = ModuleType("langchain_core.prompts")
+sys.modules["langchain_core"].messages.HumanMessage = object
+sys.modules["langchain_core"].output_parsers.StrOutputParser = object
+sys.modules["langchain_core"].prompts.ChatPromptTemplate = object
+sys.modules["langchain_openai"].chat_models = ModuleType("langchain_openai.chat_models")
+
+
+class _Dummy:
+    def __init__(self, *a, **k):
+        pass
+
+
+sys.modules["langchain_openai"].chat_models.ChatOpenAI = _Dummy
+sys.modules["langchain_openai"].OpenAIEmbeddings = _Dummy
+sys.modules["langchain.retrievers.multi_vector"].MultiVectorRetriever = object
+sys.modules["langchain.storage"].InMemoryStore = object
+sys.modules["langchain_community.vectorstores"].FAISS = object
+sys.modules["langchain_core.documents"].Document = object
+sys.modules["langchain_text_splitters"].NLTKTextSplitter = object
+sys.modules["IPython"].display = ModuleType("IPython.display")
+sys.modules["IPython"].display.HTML = lambda *a, **k: None
+sys.modules["IPython"].display.display = lambda *a, **k: None
+sys.modules["dotenv"].load_dotenv = lambda *a, **k: None
+sys.modules["main"].multi_modal_rag_chain = lambda *a, **k: None
+sys.modules["utils.LLM_Tool"].text_embedding_3_large = None
+
+import app
+
+
+def test_list_user_files(monkeypatch, tmp_path):
+    monkeypatch.setattr(app, "DATABASE_ROOT", str(tmp_path / "db"))
+    monkeypatch.setattr(app, "UPLOAD_ROOT", str(tmp_path / "uploads"))
+
+    user_dir = Path(app.UPLOAD_ROOT) / "alice"
+    user_dir.mkdir(parents=True)
+    (user_dir / "a.pdf").write_text("x")
+    (user_dir / "b.docx").write_text("y")
+
+    files = app.list_user_files("alice")
+    assert set(files) == {"a.pdf", "b.docx"}


### PR DESCRIPTION
## Summary
- list uploaded files via new `/files` endpoint
- add delete buttons in frontend and show uploaded files
- document `/files` in README
- test helper for listing user files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b74d3856c8322927189cd03c2790e